### PR TITLE
build: upload both executable to the same artifact

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,10 +39,7 @@ jobs:
       - name: Upload PR artifact (Windows)
         uses: actions/upload-artifact@v3
         with:
-          name: Homework Companion (Windows)
-          path: ./dist/*.exe
-      - name: Upload PR artifact (macOS)
-        uses: actions/upload-artifact@v3
-        with:
-          name: Homework Companion (macOS)
-          path: ./dist/*.dmg          
+          name: Homework Companion
+          path: |
+            ./dist/*.exe
+            ./dist/*.dmg


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
As artifacts are always zipped when downloaded through the GitHub website, it makes sense to combine them into the same artifact.
