### PR TITLE
ci: prevent auto publish

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,8 +18,6 @@ jobs:
         run: npm ci
       - name: Build Homework Companion
         run: npm run build:crossplatform
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Print ./dist contents
         run: ls dist
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
         run: npm ci
       - name: Build Homework Companion
         run: npm run build:crossplatform
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Print ./dist contents
         run: ls dist
       - name: Publish

--- a/stable.electron-builder.json
+++ b/stable.electron-builder.json
@@ -1,6 +1,7 @@
 {
   "appId": "app.examplewastaken-studios.homework-companion",
   "productName": "Homework Companion",
+  "publish": null,
   "mac": {
     "category": "public.app-category.education",
     "target": "dmg",


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
electron-builder by default detects CI environments and tries to publish the application automatically. This PR prevents that as publishing is done separately.

